### PR TITLE
Feature/2eqzyvb7 use fallbackcontroller for error handling

### DIFF
--- a/lib/do_it/repo.ex
+++ b/lib/do_it/repo.ex
@@ -2,4 +2,16 @@ defmodule DoIt.Repo do
   use Ecto.Repo,
     otp_app: :do_it,
     adapter: Ecto.Adapters.Postgres
+    alias DoIt.List
+
+  def get_list(id) do
+    case get(List, id) do
+      nil -> {:error, :not_found}
+      %List{} = list -> {:ok, list}
+    end
+  end
+
+  def create_list(params) do
+    List.create_changeset(params) |> insert()
+  end
 end

--- a/lib/do_it/repo.ex
+++ b/lib/do_it/repo.ex
@@ -2,7 +2,8 @@ defmodule DoIt.Repo do
   use Ecto.Repo,
     otp_app: :do_it,
     adapter: Ecto.Adapters.Postgres
-    alias DoIt.List
+
+  alias DoIt.List
 
   def get_list(id) do
     case get(List, id) do

--- a/lib/do_it_web/controllers/fallback_controller.ex
+++ b/lib/do_it_web/controllers/fallback_controller.ex
@@ -1,0 +1,17 @@
+defmodule DoItWeb.FallbackController do
+  use DoItWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(DoItWeb.ErrorView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(DoItWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/do_it_web/controllers/list_controller.ex
+++ b/lib/do_it_web/controllers/list_controller.ex
@@ -1,65 +1,28 @@
 defmodule DoItWeb.ListController do
   use DoItWeb, :controller
-  alias DoIt.List
   alias DoIt.Repo
+  action_fallback DoItWeb.FallbackController
 
   def show(conn, %{"id" => id}) do
-    case Repo.get(List, id) do
-      %List{} = list ->
-        conn
-        |> put_status(200)
-        |> render("show.json", list: list)
-
-      nil ->
-        conn
-        |> put_status(404)
-        |> put_view(DoItWeb.ErrorView)
-        |> render("404.json")
+    with {:ok, list} <- Repo.get_list(id) do
+      conn
+      |> put_status(200)
+      |> render("show.json", list: list)
     end
   end
 
   def create(conn, params) do
-    result =
-      params
-      |> List.create_changeset()
-      |> Repo.insert()
-
-    case result do
-      {:ok, list} ->
-        conn
-        |> put_status(200)
-        |> render("show.json", list: list)
-
-      {:error, changeset} ->
-        conn
-        |> put_status(400)
-        |> put_view(DoItWeb.ErrorView)
-        |> render("error.json", changeset: changeset)
+    with {:ok, list} <- Repo.create_list(params) do
+      conn
+      |> put_status(200)
+      |> render("show.json", list: list)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    case Repo.get(List, id) do
-      list = %List{} ->
-        case Repo.delete(list) do
-          {:ok, _struct} ->
-            conn
-            |> put_status(200)
-            |> put_view(DoItWeb.ErrorView)
-            |> render("200.json")
-
-          {:error, changeset} ->
-            conn
-            |> put_status(400)
-            |> put_view(DoItWeb.ErrorView)
-            |> render("error.json", changeset: changeset)
-        end
-
-      nil ->
-        conn
-        |> put_status(404)
-        |> put_view(DoItWeb.ErrorView)
-        |> render("404.json")
+    with {:ok, list} <- Repo.get_list(id),
+         {:ok, _list} <- Repo.delete(list) do
+      send_resp(conn, :no_content, "")
     end
   end
 end

--- a/test/do_it_web/controllers/list_controller_test.exs
+++ b/test/do_it_web/controllers/list_controller_test.exs
@@ -11,7 +11,7 @@ defmodule DoItWeb.ListControllerTest do
     end
 
     test "renders 404 error when list with that id does not exists", %{conn: conn} do
-      conn = get(conn, Routes.list_path(conn, :show, 123786876))
+      conn = get(conn, Routes.list_path(conn, :show, 123_786_876))
       assert json_response(conn, 404) == "Not Found"
     end
   end
@@ -25,8 +25,9 @@ defmodule DoItWeb.ListControllerTest do
     test "renders error when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.list_path(conn, :create), title: "Go")
 
-      assert json_response(conn, 422)["errors"] == %{"title" => ["should be at least 3 character(s)"]}
-
+      assert json_response(conn, 422)["errors"] == %{
+               "title" => ["should be at least 3 character(s)"]
+             }
     end
   end
 

--- a/test/do_it_web/controllers/list_controller_test.exs
+++ b/test/do_it_web/controllers/list_controller_test.exs
@@ -25,16 +25,16 @@ defmodule DoItWeb.ListControllerTest do
     test "renders error when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.list_path(conn, :create), title: "Go")
 
-      assert json_response(conn, 400)["errors"] == %{"title" => ["should be at least 3 character(s)"]}
+      assert json_response(conn, 422)["errors"] == %{"title" => ["should be at least 3 character(s)"]}
 
     end
   end
 
   describe "delete" do
-    test "responds with 200 after successful deletion", %{conn: conn} do
+    test "responds with 204 after successful deletion", %{conn: conn} do
       {:ok, list} = Repo.insert(%List{title: "Title"})
       conn = delete(conn, Routes.list_path(conn, :delete, list))
-      assert json_response(conn, 200)
+      assert response(conn, 204)
     end
 
     test "responds with 404 if no list is found", %{conn: conn} do


### PR DESCRIPTION
A lot of refactoring to make the ListController more readable, including:

- get_list function in Repo
- create_list function in Repo
- Only processing successful cases in the ListController
- Failures are handled by the FallbackController
- Successful list deletions now send a 204 (no content) as response