### PR TITLE
Feature/utbrc290 add todocontroller create

### DIFF
--- a/lib/do_it/repo.ex
+++ b/lib/do_it/repo.ex
@@ -4,6 +4,7 @@ defmodule DoIt.Repo do
     adapter: Ecto.Adapters.Postgres
 
   alias DoIt.List
+  alias DoIt.Todo
 
   def get_list(id) do
     case get(List, id) do
@@ -19,5 +20,13 @@ defmodule DoIt.Repo do
   def update_list(list, title) do
     List.changeset(list, %{title: title})
     |> update()
+  end
+
+  def load_list_with_todos(list_id) do
+    {:ok, list} = get_list(list_id)
+    preload(list, :todos)
+  end
+  def create_todo(params) do
+    Todo.create_changeset(params) |> insert()
   end
 end

--- a/lib/do_it/repo.ex
+++ b/lib/do_it/repo.ex
@@ -22,10 +22,6 @@ defmodule DoIt.Repo do
     |> update()
   end
 
-  def load_list_with_todos(list_id) do
-    {:ok, list} = get_list(list_id)
-    preload(list, :todos)
-  end
   def create_todo(params) do
     Todo.create_changeset(params) |> insert()
   end

--- a/lib/do_it/repo.ex
+++ b/lib/do_it/repo.ex
@@ -5,6 +5,10 @@ defmodule DoIt.Repo do
 
   alias DoIt.{List, Todo}
 
+  @list_does_not_exist [
+    list: {"does not exist", [constraint: :assoc, constraint_name: "todos_list_id_fkey"]}
+  ]
+
   def get_list(id) do
     case get(List, id) do
       nil -> {:error, :not_found}
@@ -25,5 +29,15 @@ defmodule DoIt.Repo do
     params
     |> Todo.create_changeset()
     |> insert()
+    |> handle_unexisting_list_error()
+  end
+
+  defp handle_unexisting_list_error(insert_return) do
+    {status, result} = insert_return
+    if Map.has_key?(result, :errors) && result.errors == @list_does_not_exist do
+      {:error, :not_found}
+    else
+      {status, result}
+    end
   end
 end

--- a/lib/do_it_web/controllers/fallback_controller.ex
+++ b/lib/do_it_web/controllers/fallback_controller.ex
@@ -1,6 +1,15 @@
 defmodule DoItWeb.FallbackController do
   use DoItWeb, :controller
 
+  @list_does_not_exist [
+    list: {"does not exist", [constraint: :assoc, constraint_name: "todos_list_id_fkey"]}
+  ]
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset})
+      when changeset.errors == @list_does_not_exist do
+    call(conn, {:error, :not_found})
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(400)

--- a/lib/do_it_web/controllers/fallback_controller.ex
+++ b/lib/do_it_web/controllers/fallback_controller.ex
@@ -1,15 +1,6 @@
 defmodule DoItWeb.FallbackController do
   use DoItWeb, :controller
 
-  @list_does_not_exist [
-    list: {"does not exist", [constraint: :assoc, constraint_name: "todos_list_id_fkey"]}
-  ]
-
-  def call(conn, {:error, %Ecto.Changeset{} = changeset})
-      when changeset.errors == @list_does_not_exist do
-    call(conn, {:error, :not_found})
-  end
-
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(400)

--- a/lib/do_it_web/controllers/list_controller.ex
+++ b/lib/do_it_web/controllers/list_controller.ex
@@ -34,6 +34,7 @@ defmodule DoItWeb.ListController do
   end
 
   defp display_list(conn, list) do
+    list = Repo.preload(list, :todos)
     conn
     |> put_status(200)
     |> render("show.json", list: list)

--- a/lib/do_it_web/controllers/list_controller.ex
+++ b/lib/do_it_web/controllers/list_controller.ex
@@ -35,6 +35,7 @@ defmodule DoItWeb.ListController do
 
   defp display_list(conn, list) do
     list = Repo.preload(list, :todos)
+
     conn
     |> put_status(200)
     |> render("show.json", list: list)

--- a/lib/do_it_web/controllers/todo_controller.ex
+++ b/lib/do_it_web/controllers/todo_controller.ex
@@ -5,14 +5,7 @@ defmodule DoItWeb.TodoController do
 
   def create(conn, params) do
     with {:ok, todo} <- Repo.create_todo(params) do
-      Repo.load_list_with_todos(todo.list_id) |> display_list(conn)
+      redirect(conn, to: Routes.list_path(conn, :show, todo.list_id))
     end
-  end
-
-  defp display_list(list, conn) do
-      conn
-      |> put_status(200)
-      |> put_view(DoItWeb.ListView)
-      |> render("show.json", list: list)
   end
 end

--- a/lib/do_it_web/controllers/todo_controller.ex
+++ b/lib/do_it_web/controllers/todo_controller.ex
@@ -1,0 +1,18 @@
+defmodule DoItWeb.TodoController do
+  use DoItWeb, :controller
+  alias DoIt.Repo
+  action_fallback DoItWeb.FallbackController
+
+  def create(conn, params) do
+    with {:ok, todo} <- Repo.create_todo(params) do
+      Repo.load_list_with_todos(todo.list_id) |> display_list(conn)
+    end
+  end
+
+  defp display_list(list, conn) do
+      conn
+      |> put_status(200)
+      |> put_view(DoItWeb.ListView)
+      |> render("show.json", list: list)
+  end
+end

--- a/lib/do_it_web/router.ex
+++ b/lib/do_it_web/router.ex
@@ -22,7 +22,9 @@ defmodule DoItWeb.Router do
   scope "/api", DoItWeb do
     pipe_through :api
 
-    resources "/list", ListController, except: [:edit, :new, :index]
+    resources "/list", ListController, except: [:edit, :new, :index] do
+      resources "/todo", TodoController, only: [:create]
+    end
   end
 
   # Enables LiveDashboard only for development

--- a/lib/do_it_web/views/list_view.ex
+++ b/lib/do_it_web/views/list_view.ex
@@ -6,6 +6,6 @@ defmodule DoItWeb.ListView do
   end
 
   def render("list.json", %{list: list}) do
-    %{title: list.title}
+    %{title: list.title, id: list.id}
   end
 end

--- a/lib/do_it_web/views/list_view.ex
+++ b/lib/do_it_web/views/list_view.ex
@@ -6,6 +6,17 @@ defmodule DoItWeb.ListView do
   end
 
   def render("list.json", %{list: list}) do
-    %{title: list.title, id: list.id}
+    %{
+      id: list.id,
+      title: list.title,
+      todos: render_many(list.todos, DoItWeb.ListView, "todo.json", as: :todo)
+    }
+  end
+
+  def render("todo.json", %{todo: todo}) do
+    %{
+      description: todo.description,
+      done: todo.done
+    }
   end
 end

--- a/test/do_it_web/controllers/list_controller_test.exs
+++ b/test/do_it_web/controllers/list_controller_test.exs
@@ -5,7 +5,7 @@ defmodule DoItWeb.ListControllerTest do
     test "renders list when list with that id exists", %{conn: conn} do
       list = insert(:list, %{title: "Hello"})
       conn = get(conn, Routes.list_path(conn, :show, list.id))
-      assert json_response(conn, 200)["data"] == %{"title" => "Hello"}
+      assert json_response(conn, 200)["data"]["title"] == "Hello"
     end
 
     test "renders 404 error when list with that id does not exists", %{conn: conn} do
@@ -17,7 +17,7 @@ defmodule DoItWeb.ListControllerTest do
   describe "create" do
     test "renders list when data is valid", %{conn: conn} do
       conn = post(conn, Routes.list_path(conn, :create), title: "Good Title")
-      assert json_response(conn, 200)["data"] == %{"title" => "Good Title"}
+      assert json_response(conn, 200)["data"]["title"] == "Good Title"
     end
 
     test "renders error when data is invalid", %{conn: conn} do
@@ -47,7 +47,7 @@ defmodule DoItWeb.ListControllerTest do
     test "renders 200 if list exists and change is valid", %{conn: conn} do
       list = insert(:list)
       conn = put(conn, Routes.list_path(conn, :update, list.id), title: "New Title")
-      assert json_response(conn, 200)["data"] == %{"title" => "New Title"}
+      assert json_response(conn, 200)["data"]["title"] == "New Title"
     end
   end
 

--- a/test/do_it_web/controllers/todo_controller_test.exs
+++ b/test/do_it_web/controllers/todo_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule DoItWeb.TodoControllerTest do
+  use DoItWeb.ConnCase
+
+  @valid_description %{description: "Wash dishes"}
+  @invalid_description %{description: ""}
+
+  describe "create" do
+    test "renders 404 when list does not exist" do
+      conn = build_conn()
+      path = Routes.list_todo_path(conn, :create, 461_212)
+      conn = post(conn, path, @valid_description)
+      assert response(conn, 404)
+    end
+
+    test "renders 400 if invalid data given" do
+      conn = build_conn()
+      list = insert(:list)
+      path = Routes.list_todo_path(conn, :create, list.id)
+      conn = post(conn, path, @invalid_description)
+      assert response(conn, 400)
+    end
+
+    test "saves todo and redirects to ListController#show when data valid and list exists" do
+      conn = build_conn()
+      list = insert(:list)
+      path = Routes.list_todo_path(conn, :create, list.id)
+      conn = post(conn, path, @valid_description)
+      todos = DoIt.Repo.preload(list, :todos).todos
+      assert Elixir.List.last(todos).description == @valid_description.description
+      assert redirected_to(conn) =~ "/api/list/#{list.id}"
+    end
+  end
+end

--- a/test/do_it_web/controllers/todo_controller_test.exs
+++ b/test/do_it_web/controllers/todo_controller_test.exs
@@ -5,23 +5,20 @@ defmodule DoItWeb.TodoControllerTest do
   @invalid_description %{description: ""}
 
   describe "create" do
-    test "renders 404 when list does not exist" do
-      conn = build_conn()
+    test "renders 404 when list does not exist", %{conn: conn} do
       path = Routes.list_todo_path(conn, :create, 461_212)
       conn = post(conn, path, @valid_description)
       assert response(conn, 404)
     end
 
-    test "renders 400 if invalid data given" do
-      conn = build_conn()
+    test "renders 400 if invalid data given", %{conn: conn} do
       list = insert(:list)
       path = Routes.list_todo_path(conn, :create, list.id)
       conn = post(conn, path, @invalid_description)
       assert response(conn, 400)
     end
 
-    test "saves todo and redirects to ListController#show when data valid and list exists" do
-      conn = build_conn()
+    test "saves todo and redirects to ListController#show when data valid and list exists", %{conn: conn} do
       list = insert(:list)
       path = Routes.list_todo_path(conn, :create, list.id)
       conn = post(conn, path, @valid_description)


### PR DESCRIPTION
This branch adds the functionality to create a todo for an existing list. The errors are handled by a FallbackController and a success redirects to the ListController#show.

Also I updated how lists are rendered for show: Now the todos and the id is rendered as well.

https://trello.com/c/utbrc290/28-add-todocontrollercreate