### PR TITLE
Task/enen4ccv use setup blocks in tests

### DIFF
--- a/test/do_it/list_test.exs
+++ b/test/do_it/list_test.exs
@@ -2,7 +2,7 @@ defmodule DoIt.ListTest do
   use DoIt.DataCase, async: true
   alias DoIt.List
 
-  @long_title "This is a very long title. It is longer than onehundred characters. This is really very long. Who would give their todo list such a long title?"
+  @long_title String.duplicate("a", 101)
 
   test "title must be at least three characters long" do
     changeset = List.changeset(%List{}, %{title: "In"})

--- a/test/do_it_web/controllers/list_controller_test.exs
+++ b/test/do_it_web/controllers/list_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule DoItWeb.ListControllerTest do
   use DoItWeb.ConnCase
 
-  @valid_title %{title: "My List"}
+  @valid_title params_for(:list)
   @too_short_title %{title: "Go"}
 
   defp insert_list(_context) do

--- a/test/do_it_web/controllers/list_controller_test.exs
+++ b/test/do_it_web/controllers/list_controller_test.exs
@@ -1,11 +1,19 @@
 defmodule DoItWeb.ListControllerTest do
   use DoItWeb.ConnCase
 
+  @valid_title %{title: "My List"}
+  @too_short_title %{title: "Go"}
+
+  defp insert_list(_context) do
+    %{list: insert(:list)}
+  end
+
   describe "show" do
-    test "renders list when list with that id exists", %{conn: conn} do
-      list = insert(:list, %{title: "Hello"})
+    setup :insert_list
+
+    test "renders list when list with that id exists", %{conn: conn, list: list} do
       conn = get(conn, Routes.list_path(conn, :show, list.id))
-      assert json_response(conn, 200)["data"]["title"] == "Hello"
+      assert json_response(conn, 200)["data"]["title"] == list.title
     end
 
     test "renders 404 error when list with that id does not exists", %{conn: conn} do
@@ -16,12 +24,12 @@ defmodule DoItWeb.ListControllerTest do
 
   describe "create" do
     test "renders list when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.list_path(conn, :create), title: "Good Title")
-      assert json_response(conn, 200)["data"]["title"] == "Good Title"
+      conn = post(conn, Routes.list_path(conn, :create), @valid_title)
+      assert json_response(conn, 200)["data"]["title"] == @valid_title.title
     end
 
     test "renders error when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.list_path(conn, :create), title: "Go")
+      conn = post(conn, Routes.list_path(conn, :create), @too_short_title)
 
       assert json_response(conn, 400)["errors"] == %{
                "title" => ["should be at least 3 character(s)"]
@@ -30,13 +38,14 @@ defmodule DoItWeb.ListControllerTest do
   end
 
   describe "update" do
+    setup :insert_list
+
     test "renders 404 if list does not exist", %{conn: conn} do
-      conn = put(conn, Routes.list_path(conn, :update, 12_324), title: "Hello")
+      conn = put(conn, Routes.list_path(conn, :update, 12_324), @valid_title)
       assert response(conn, 404)
     end
 
-    test "renders 400 if change is invalid", %{conn: conn} do
-      list = insert(:list)
+    test "renders 400 if change is invalid", %{conn: conn, list: list} do
       conn = put(conn, Routes.list_path(conn, :update, list.id), title: "")
 
       assert json_response(conn, 400)["errors"] == %{
@@ -44,16 +53,16 @@ defmodule DoItWeb.ListControllerTest do
              }
     end
 
-    test "renders 200 if list exists and change is valid", %{conn: conn} do
-      list = insert(:list)
+    test "renders 200 if list exists and change is valid", %{conn: conn, list: list} do
       conn = put(conn, Routes.list_path(conn, :update, list.id), title: "New Title")
       assert json_response(conn, 200)["data"]["title"] == "New Title"
     end
   end
 
   describe "delete" do
-    test "responds with 204 after successful deletion", %{conn: conn} do
-      list = insert(:list)
+    setup :insert_list
+
+    test "responds with 204 after successful deletion", %{conn: conn, list: list} do
       conn = delete(conn, Routes.list_path(conn, :delete, list))
       assert response(conn, 204)
     end

--- a/test/do_it_web/controllers/todo_controller_test.exs
+++ b/test/do_it_web/controllers/todo_controller_test.exs
@@ -19,10 +19,6 @@ defmodule DoItWeb.TodoControllerTest do
     %{todo: insert(:todo)}
   end
 
-  defp count_todos(_context) do
-    %{todo_count: Repo.aggregate(Todo, :count)}
-  end
-
   describe "create" do
     setup [:insert_list, :get_create_list_path]
 
@@ -93,22 +89,21 @@ defmodule DoItWeb.TodoControllerTest do
   end
 
   describe "delete" do
-    setup [:insert_todo, :count_todos]
+    setup [:insert_todo]
 
-    test "renders 404 if todo does not exist", %{conn: conn, todo_count: todo_count} do
+    test "renders 404 if todo does not exist", %{conn: conn} do
       conn = delete(conn, Routes.todo_path(conn, :delete, 123))
       assert response(conn, 404)
-      assert Repo.aggregate(Todo, :count) == todo_count
+      assert Repo.aggregate(Todo, :count) == 1
     end
 
     test "renders 204 if todo exists and is successfully deleted", %{
       conn: conn,
-      todo: todo,
-      todo_count: todo_count
+      todo: todo
     } do
       conn = delete(conn, Routes.todo_path(conn, :delete, todo.id))
       assert response(conn, 204)
-      assert Repo.aggregate(Todo, :count) == todo_count - 1
+      assert Repo.all(Todo) == []
     end
   end
 end

--- a/test/do_it_web/controllers/todo_controller_test.exs
+++ b/test/do_it_web/controllers/todo_controller_test.exs
@@ -7,25 +7,41 @@ defmodule DoItWeb.TodoControllerTest do
   @invalid_description %{description: ""}
   @valid_update_params %{description: "Wash dishes", done: true}
 
+  defp insert_list(_context) do
+    %{list: insert(:list)}
+  end
+
+  defp get_create_list_path(%{list: list, conn: conn}) do
+    %{path: Routes.list_todo_path(conn, :create, list.id)}
+  end
+
+  defp insert_todo(_context) do
+    %{todo: insert(:todo)}
+  end
+
+  defp count_todos(_context) do
+    %{todo_count: Repo.aggregate(Todo, :count)}
+  end
+
   describe "create" do
+    setup [:insert_list, :get_create_list_path]
+
     test "renders 404 when list does not exist", %{conn: conn} do
       path = Routes.list_todo_path(conn, :create, 461_212)
       conn = post(conn, path, @valid_description)
       assert response(conn, 404)
     end
 
-    test "renders 400 if invalid data given", %{conn: conn} do
-      list = insert(:list)
-      path = Routes.list_todo_path(conn, :create, list.id)
+    test "renders 400 if invalid data given", %{conn: conn, path: path} do
       conn = post(conn, path, @invalid_description)
       assert response(conn, 400)
     end
 
     test "saves todo and redirects to ListController#show when data valid and list exists", %{
-      conn: conn
+      conn: conn,
+      list: list,
+      path: path
     } do
-      list = insert(:list)
-      path = Routes.list_todo_path(conn, :create, list.id)
       conn = post(conn, path, @valid_description)
       todos = DoIt.Repo.preload(list, :todos).todos
       assert List.last(todos).description == @valid_description.description
@@ -34,19 +50,19 @@ defmodule DoItWeb.TodoControllerTest do
   end
 
   describe "update" do
+    setup :insert_todo
+
     test "renders 404 when todo does not exist", %{conn: conn} do
       conn = patch(conn, Routes.todo_path(conn, :update, 123))
       assert response(conn, 404)
     end
 
-    test "renders 400 if updated description is invalid", %{conn: conn} do
-      todo = insert(:todo)
+    test "renders 400 if updated description is invalid", %{conn: conn, todo: todo} do
       conn = patch(conn, Routes.todo_path(conn, :update, todo.id), @invalid_description)
       assert response(conn, 400)
     end
 
-    test "renders 200 and shows updated todo if params are valid", %{conn: conn} do
-      todo = insert(:todo)
+    test "renders 200 and shows updated todo if params are valid", %{conn: conn, todo: todo} do
       conn = patch(conn, Routes.todo_path(conn, :update, todo.id), @valid_update_params)
 
       assert json_response(conn, 200) == %{
@@ -58,13 +74,14 @@ defmodule DoItWeb.TodoControllerTest do
   end
 
   describe "check_done" do
+    setup :insert_todo
+
     test "renders 404 if there is no todo with that id", %{conn: conn} do
       conn = patch(conn, Routes.todo_path(conn, :check_done, 123))
       assert response(conn, 404)
     end
 
-    test "renders 200 and checked todo if there is a todo with that id", %{conn: conn} do
-      todo = insert(:todo)
+    test "renders 200 and checked todo if there is a todo with that id", %{conn: conn, todo: todo} do
       conn = patch(conn, Routes.todo_path(conn, :check_done, todo.id))
 
       assert json_response(conn, 200) == %{
@@ -76,16 +93,19 @@ defmodule DoItWeb.TodoControllerTest do
   end
 
   describe "delete" do
-    test "renders 404 if todo does not exist", %{conn: conn} do
-      todo_count = Repo.aggregate(Todo, :count)
+    setup [:insert_todo, :count_todos]
+
+    test "renders 404 if todo does not exist", %{conn: conn, todo_count: todo_count} do
       conn = delete(conn, Routes.todo_path(conn, :delete, 123))
       assert response(conn, 404)
       assert Repo.aggregate(Todo, :count) == todo_count
     end
 
-    test "renders 204 if todo exists and is successfully deleted", %{conn: conn} do
-      todo = insert(:todo)
-      todo_count = Repo.aggregate(Todo, :count)
+    test "renders 204 if todo exists and is successfully deleted", %{
+      conn: conn,
+      todo: todo,
+      todo_count: todo_count
+    } do
       conn = delete(conn, Routes.todo_path(conn, :delete, todo.id))
       assert response(conn, 204)
       assert Repo.aggregate(Todo, :count) == todo_count - 1


### PR DESCRIPTION
Refactoring of the tests (mostly controller tests) to make everything DRYer and more readable.